### PR TITLE
Improve viewer layout responsiveness

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -138,9 +138,11 @@ body.is-locked {
 }
 
 .viewer__stage {
-  width: 100%;
+  width: min(100%, 560px);
   max-width: 560px;
   aspect-ratio: 9 / 16;
+  height: clamp(360px, calc(100vh - 160px), 880px);
+  height: clamp(360px, calc(100dvh - 160px), 880px);
   background: var(--canvas);
   border-radius: 32px;
   display: flex;
@@ -658,7 +660,7 @@ body.is-locked {
 
   .feed {
     flex: 1;
-    min-height: 100vh;
+    min-height: auto;
     position: relative;
     gap: 0;
   }
@@ -688,27 +690,34 @@ body.is-locked {
   }
 
   .viewer {
-    height: 100vh;
+    min-height: 100vh;
+    min-height: 100dvh;
+    padding-bottom: 0;
   }
 
   .viewer__stage {
     max-width: none;
     width: 100%;
-    height: 100%;
+    height: auto;
+    min-height: 100dvh;
+    aspect-ratio: auto;
     border-radius: 0;
     padding: 0;
     box-shadow: none;
     background: #000000;
+    justify-content: flex-start;
+    gap: 0;
   }
 
   .viewer__canvas {
     margin: 0;
     border-radius: 0;
     flex: none;
-    height: 100%;
     width: 100%;
     align-items: flex-end;
     padding: 24px;
+    aspect-ratio: 9 / 16;
+    height: auto;
   }
 
   .viewer__canvas::after {
@@ -728,12 +737,9 @@ body.is-locked {
   }
 
   .viewer__details {
-    position: absolute;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    padding: 32px 24px 120px;
-    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.82) 55%, rgba(0, 0, 0, 0.95) 100%);
+    position: relative;
+    padding: 32px 24px 140px;
+    background: linear-gradient(180deg, rgba(0, 0, 0, 0.7) 0%, rgba(0, 0, 0, 0.95) 100%);
     color: #ffffff;
     gap: 20px;
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import './App.css'
 
 const menuItems = [
@@ -301,7 +302,6 @@ function App() {
     [activeItem.metrics.likes, activeItem.metrics.saves, activeItem.metrics.views],
   )
 
-function App() {
   return (
     <div className={`app-shell${isMobileMenuOpen ? ' app-shell--drawer-open' : ''}`} style={{ '--accent-color': activeItem.accent }}>
       <aside className="sidebar">


### PR DESCRIPTION
## Summary
- keep the publication card within the initial viewport by constraining its height responsively
- rework the mobile layout so the publication details stack below the media and stay scrollable
- fix the missing React hook imports so the build succeeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6c55d3168833088d15be2182c7bf0